### PR TITLE
Clear publish-backend folder before rebuilding

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore ./EVEAbacus.WebUI/EVEAbacus.WebUI.csproj
       
+      - name: Clean publish-backend directory
+        run: rm -rf ./publish-backend
+
       - name: Build backend
         run: dotnet build --no-restore --configuration Release ./EVEAbacus.WebUI/EVEAbacus.WebUI.csproj
       


### PR DESCRIPTION
Error on build-backend: 

```
Jul 01 21:50:22 EVEAbacus systemd[1]: Started EVE Abacus Backend API.
Jul 01 21:50:22 EVEAbacus eveabacus-backend[27291]: Failed to load System.Private.CoreLib.dll (error code 0x8007000B)
Jul 01 21:50:22 EVEAbacus eveabacus-backend[27291]: Path: /var/www/eveabacus/System.Private.CoreLib.dll
Jul 01 21:50:22 EVEAbacus eveabacus-backend[27291]: Error message: An attempt was made to load a program with an incorrect format.
Jul 01 21:50:22 EVEAbacus eveabacus-backend[27291]:  (0x8007000B)
Jul 01 21:50:22 EVEAbacus eveabacus-backend[27291]: Failed to create CoreCLR, HRESULT: 0x8007000B
Jul 01 21:50:22 EVEAbacus systemd[1]: eveabacus-backend.service: Main process exited, code=exited, status=137/n/a
Jul 01 21:50:22 EVEAbacus systemd[1]: eveabacus-backend.service: Failed with result 'exit-code'.
```

Solution is to clear publish-backend folder, since artifacts were likely left over from the previous build in the windows environment. This ensures a clean build.

Added step to pipeline before publish: 
```
- name: Clean publish-backend directory
  run: rm -rf ./publish-backend
```