### PR TITLE
Creating node-linker=hoisted in .npmrc file.

### DIFF
--- a/eve-abacus-webui/.npmrc
+++ b/eve-abacus-webui/.npmrc
@@ -1,0 +1,1 @@
+node-linker=hoisted 

--- a/eve-abacus-webui/next.config.ts
+++ b/eve-abacus-webui/next.config.ts
@@ -3,6 +3,12 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   /* config options here */
   output: 'standalone',
+  // Force Next.js to include all dependencies
+  transpilePackages: [],
+  // Ensure styled-jsx is properly handled
+  compiler: {
+    styledComponents: false,
+  },
 };
 
 export default nextConfig;

--- a/eve-abacus-webui/scripts/postbuild.js
+++ b/eve-abacus-webui/scripts/postbuild.js
@@ -9,3 +9,26 @@ if (fs.existsSync(standaloneDir) && fs.existsSync(sourceStatic)) {
   fs.mkdirSync(path.dirname(targetStatic), { recursive: true });
   fs.cpSync(sourceStatic, targetStatic, { recursive: true });
 }
+
+// Ensure styled-jsx is available in standalone build
+const styledJsxSource = path.join('node_modules', 'styled-jsx');
+const styledJsxTarget = path.join(standaloneDir, 'node_modules', 'styled-jsx');
+
+if (fs.existsSync(styledJsxSource) && !fs.existsSync(styledJsxTarget)) {
+  console.log('Copying styled-jsx to standalone build...');
+  fs.mkdirSync(path.dirname(styledJsxTarget), { recursive: true });
+  fs.cpSync(styledJsxSource, styledJsxTarget, { recursive: true });
+}
+
+// Copy other potentially missing dependencies
+const criticalDeps = ['@swc/helpers'];
+criticalDeps.forEach(dep => {
+  const depSource = path.join('node_modules', dep);
+  const depTarget = path.join(standaloneDir, 'node_modules', dep);
+  
+  if (fs.existsSync(depSource) && !fs.existsSync(depTarget)) {
+    console.log(`Copying ${dep} to standalone build...`);
+    fs.mkdirSync(path.dirname(depTarget), { recursive: true });
+    fs.cpSync(depSource, depTarget, { recursive: true });
+  }
+});


### PR DESCRIPTION
Makes pnpm create a flat node_modules structure instead of using symlinks to resolve dependency resolution issues in standalone build.

https://github.com/vercel/next.js/issues/50072#issuecomment-2565387476
explains the issue.