### PR TITLE
.next/static is still not being included in the Frontend artifacts

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -370,9 +370,16 @@ jobs:
             cp ./eveabacus-frontend.service ./frontend-build/
           fi
           
+          # Debugging
+          echo "Contents of frontend-build before upload:"
+          ls -la ./frontend-build
+          ls -la ./frontend-build/.next
+          ls -la ./frontend-build/.next/static
+
           echo "Final artifacts structure:"
           find ./frontend-build -type d | head -10
         working-directory: ./
+
       
       - name: Upload frontend artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Debugging pull; .next/static folder is not being included in the frontend artifact upload, likely due to the fact that the .next folder is hidden. Considering options, but want to confirm.